### PR TITLE
Add Markdown spec for easier review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-Solar Forecast Arbiter OpenAPI Specification
+# Solar Forecast Arbiter OpenAPI Specification
 
+*A provisional specification written in markdown can be found in [markdown_spec.md](markdown_spec.md).*
+
+
+The [api_spec.yaml](api_spec.yaml) file is an api spec written using [Open API](https://www.openapis.org/) (formerly known as the Swagger specification). This allows us to provide a standardized api specification which may be rendered as interactive documentation for our api. See [Swaggerhub Petstore Example](https://petstore.swagger.io/#/).
+
+To make it simpler to provide feedback and view the spec while being developed a markdown file has been provided as noted above.
 This spec can be viewed locally using [Swagger Editor](https://github.com/swagger-api/swagger-editor).
 Note that the editor does not work on a file in place, and instead stores a copy in your browser. You will
 Need to import the spec, edit, and download it from your browser and manually move/rename it.
 
-Proposed responses can be found in [json responses](json_responses.md).
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This spec can be viewed locally using [Swagger Editor](https://github.com/swagge
 Note that the editor does not work on a file in place, and instead stores a copy in your browser. You will
 Need to import the spec, edit, and download it from your browser and manually move/rename it.
 
+Proposed responses can be found in [json responses](json_responses.md).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 Solar Forecast Arbiter OpenAPI Specification
 
+This spec can be viewed locally using [Swagger Editor](https://github.com/swagger-api/swagger-editor).
+Note that the editor does not work on a file in place, and instead stores a copy in your browser. You will
+Need to import the spec, edit, and download it from your browser and manually move/rename it.
+

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.2'
+openapi: 3.0.2
 info:
   description: The Solar Forecast Arbiter API.
   version: 0.0.0
@@ -7,294 +7,312 @@ info:
     name: Solar Forecast Arbiter Team
     url: solarforecastarbiter.org
     email: info@solarforecastarbiter.org
-servers: 
-- url: api.solarforecastarbiter.org
-  description: The production server.
+servers:
+  - url: api.solarforecastarbiter.org
+    description: The production server.
 components:
   parameters:
     uuid:
       name: uuid
-      description: 'Universally Unique Identifier for the resource.'
+      description: Universally Unique Identifier for the resource.
       in: path
       required: true
       schema:
         type: string
+    start:
+      name: start
+      description: ISO datetime for start of data/forecast.
+      in: query
+      required: true
+      schema: 
+        type: string
+    end:
+      name: end
+      description: ISO datetime for end of data/forecast.
+      in: query
+      required: true
+      schema:
+        type: string
 tags:
-- name: Observations
-  description: Interact with observation data.
-- name: Forecasts
-  description: Interact with forecast data.
-- name: Reference
-  description: Interact with Reference data.
-- name: User
-  description: Manage accounts/users
-- name: Organization
-  description: Manage organizations.
-- name: Trial
-  description: Manage trials.
+  - name: Observations
+    description: Interact with observation data.
+  - name: Forecasts
+    description: Interact with forecast data.
+  - name: Reference
+    description: Interact with Reference data.
+  - name: User
+    description: Manage accounts/users
+  - name: Organization
+    description: Manage organizations.
+  - name: Trial
+    description: Manage trials.
 paths:
   /observations:
-    post: 
+    post:
       summary: Add a new observation data point.
-      description: 'Creates a new data point from metadata and returns a uuid.'
+      description: Creates a new data point from metadata and returns a uuid.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Observations
+      tags:
+        - Observations
     get:
       summary: List uuids of observation data points.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Observations
+      tags:
+        - Observations
   /observations/metadata:
     get:
       summary: Get json list of data points.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Observations
-  /observations/{uuid}:
+      tags:
+        - Observations
+  '/observations/{uuid}':
     parameters:
       - $ref: '#/components/parameters/uuid'
     get:
-      summary: 'Returns applicable endpoints for the data point.'
+      summary: Returns applicable endpoints for the data point.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
+        - Observations
     put:
-      summary: 'Update the metadata associated with a datapoint.'
+      summary: Update the metadata associated with a datapoint.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
+        - Observations
     delete:
-      summary: 'Delete the data point specified by uuid.'
+      summary: Delete the data point specified by uuid.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
-    
-  /observations/{uuid}/values:
+        - Observations
+  '/observations/{uuid}/values':
     parameters:
       - $ref: '#/components/parameters/uuid'
     post:
       summary: Add observation data to the data point.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
+        - Observations
     get:
       summary: Returns the observation data from the data point.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
-  /observations/{uuid}/metadata:
+        - Observations
+      parameters:
+      - $ref: '#/components/parameters/start'
+      - $ref: '#/components/parameters/end'
+  '/observations/{uuid}/metadata':
     parameters:
       - $ref: '#/components/parameters/uuid'
     get:
       summary: Get metadata for the resource.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Observations
+        - Observations
   /forecasts:
-    post: 
+    post:
       summary: Add a new observation data point.
-      description: 'Creates a new data point from metadata and returns a uuid.'
+      description: Creates a new data point from metadata and returns a uuid.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Forecasts
+      tags:
+        - Forecasts
     get:
       summary: List uuids of observation data points.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Forecasts
+      tags:
+        - Forecasts
   /forecasts/metadata:
     get:
       summary: Get json list of data points.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - Forecasts
-  /forecasts/{uuid}:
+      tags:
+        - Forecasts
+  '/forecasts/{uuid}':
     parameters:
       - $ref: '#/components/parameters/uuid'
     get:
-      summary: 'Returns applicable endpoints for the data point.'
+      summary: Returns applicable endpoints for the data point.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
+        - Forecasts
     put:
-      summary: 'Update the metadata associated with a data point.'
+      summary: Update the metadata associated with a data point.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
+        - Forecasts
     delete:
-      summary: 'Delete the data point specified by uuid.'
+      summary: Delete the data point specified by uuid.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
-    
-  /forecasts/{uuid}/values:
+        - Forecasts
+  '/forecasts/{uuid}/values':
     parameters:
       - $ref: '#/components/parameters/uuid'
     post:
       summary: Add forecast data to the data point.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
+        - Forecasts
     get:
       summary: Returns the forecast data from the data point.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
-  /forecasts/{uuid}/metadata:
+        - Forecasts
+      parameters:
+      - $ref: '#/components/parameters/start'
+      - $ref: '#/components/parameters/end'
+  '/forecasts/{uuid}/metadata':
     parameters:
       - $ref: '#/components/parameters/uuid'
     get:
       summary: Get metadata for the resource.
       description: ''
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Forecasts
+        - Forecasts
   /user:
     get:
       summary: List users that current user has access to manage.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - User
+      tags:
+        - User
     post:
       summary: Create a new user.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - User
-  /user/{uuid}:
+        - User
+  '/user/{uuid}':
     parameters:
-    - $ref: '#/components/parameters/uuid'
+      - $ref: '#/components/parameters/uuid'
     get:
       summary: Get information about user specified by uuid.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - User
+      tags:
+        - User
     put:
       summary: Update information for user specified by uuid.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - User
+      tags:
+        - User
     delete:
       summary: Delete the user specified by uuid.
       responses:
-        200:
+        '200':
           description: OK
-      tags: 
-      - User
+      tags:
+        - User
   /organization:
     get:
       summary: List organizations.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Organization
+        - Organization
     post:
       summary: Create a new organization.
       responses:
-        200:
+        '200':
           description: OK\
       tags:
-      - Organization
-  /organization/{uuid}:
+        - Organization
+  '/organization/{uuid}':
     parameters:
-    - $ref: '#/components/parameters/uuid'
+      - $ref: '#/components/parameters/uuid'
     get:
       summary: Get organization information by uuid.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Organization
+        - Organization
     put:
       summary: Update organization information by uui.d
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Organization
+        - Organization
   /trial:
     get:
       summary: List trials.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Trial
+        - Trial
     post:
       summary: Create new trial
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Trial
-  /trial/{uuid}:
+        - Trial
+  '/trial/{uuid}':
     parameters:
-    - $ref: '#/components/parameters/uuid'
+      - $ref: '#/components/parameters/uuid'
     put:
       summary: Update trial.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Trial
+        - Trial
     delete:
       summary: Remove a trial.
       responses:
-        200:
+        '200':
           description: OK
       tags:
-      - Trial
+        - Trial

--- a/json_responses.md
+++ b/json_responses.md
@@ -1,0 +1,127 @@
+# JSON API response objects
+Solar Forecast arbiter API response objects based on the [JSON API](https://jsonapi.org/)
+
+Observations/Forecasts
+```
+{
+	"data":{
+		"type": "observations",				# data type/ api path
+		"id": "1234567891011121314",		# uuid
+		"attributes": {                     # db fields
+			"name": "Ashland OR", 			
+			"resolution": "1 min",
+			"latitude": "42.190000",
+			"longitude": "-122.700000",
+			"elevation": "595",
+			"station_id": "94040",
+		    "abbreviation":	"AS",
+			"timezone": "Etc/GMT+8",
+			"attribution":	"NaN",
+			"source": "UO SRML",
+		},
+		"links":{
+			"self": "/observations/1234567891011121314",
+		},
+		"relationships":{
+			"provider":{
+				"data":{							# id/type of organization that provided the data
+					"type": "organizations",
+					"id": "10293847561029384756",
+				},
+			},
+		},
+	},
+	"included": [{
+		"type": "organizations",
+		"id": "10293847561029384756",
+		"attributes":{
+			"name": "University of Oregon Solar Radiation Measurement Laboratory",
+			"": "",
+		},
+		"links":{
+			"self": "/organizations/10293847561029384756",
+		},
+	}]	
+}
+```
+Updates:
+	Resources:
+	```
+	https://jsonapi.org/format/#crud-updating
+	example: updates the below observation object's timezone to UTC
+
+		PATCH /observations/<uuid> HTTP/1.1
+		Content-Type: application/vnd.api+json
+		Accept: application/vnd.api+json
+
+		{
+			"data":{
+				"type": "observations",
+				"id": "1234567891011121314",
+				"attributes": {
+					"timezone": "UTC",
+				}
+			}
+		}
+	```
+Relationships:
+	https://jsonapi.org/format/#crud-updating-relationships
+	example: updates provider to different 
+	```
+		PATCH: /observations/<uuid>/provider
+		Content-Type: application/vnd.api+json
+		Accept: application/vnd.api+json
+
+		{
+			"data": { "type": "organizations", "id": "<uuid>" }
+		}
+	```
+
+
+ORGANIZATIONS
+{
+	"data":{
+		"type": "organizations",
+		"id": "1029",
+		"attributes": {
+			"name": "UO SRML",
+			# metadata for organizations
+		},
+		"links":}
+			"self": "/organizations/1029",
+		},
+		"relationships": {
+			"users": {
+				"data": [
+					{"type": "users", "id": "12"}, #probably a uuid instead of 2 digit number
+					{"type": "users", "id": "13"},
+				] 
+			},
+			"observations": {
+				"data": [
+					{"type": "observations", "id": "<uuid>"},
+					{"type": "observations", "id": "<uuid>"},
+					{"type": "observations", "id": "<uuid>"},
+				]
+			},
+			"forecasts": {
+				"data": [
+					{"type": "forecasts", "id": "<uuid>"},
+					{"type": "forecasts", "id": "<uuid>"},
+					{"type": "forecasts", "id": "<uuid>"},
+				]
+			},
+		}
+	},
+	"included": [
+		{
+			"type": "users",
+			"id": "12",
+			"attributes":{
+				"name": "Dave",
+				...
+			},
+		},
+		...
+    ]
+}

--- a/json_responses.md
+++ b/json_responses.md
@@ -1,14 +1,15 @@
 # JSON API response objects
 Solar Forecast arbiter API response objects based on the [JSON API](https://jsonapi.org/)
 
-Observations/Forecasts
+## Observations/Forecasts
+Full Resource example.
 ```
 {
 	"data":{
-		"type": "observations",				# data type/ api path
-		"id": "1234567891011121314",		# uuid
-		"attributes": {                     # db fields
-			"name": "Ashland OR", 			
+		"type": "observations",
+		"id": "1234567891011121314",
+		"attributes": {
+			"name": "Ashland OR",
 			"resolution": "1 min",
 			"latitude": "42.190000",
 			"longitude": "-122.700000",
@@ -24,7 +25,7 @@ Observations/Forecasts
 		},
 		"relationships":{
 			"provider":{
-				"data":{							# id/type of organization that provided the data
+				"data":{
 					"type": "organizations",
 					"id": "10293847561029384756",
 				},
@@ -44,41 +45,48 @@ Observations/Forecasts
 	}]	
 }
 ```
-Updates:
-	Resources:
-	```
-	https://jsonapi.org/format/#crud-updating
-	example: updates the below observation object's timezone to UTC
+### Updating:
 
-		PATCH /observations/<uuid> HTTP/1.1
-		Content-Type: application/vnd.api+json
-		Accept: application/vnd.api+json
+Updates are handled with the `PATCH` http verb.
 
-		{
-			"data":{
-				"type": "observations",
-				"id": "1234567891011121314",
-				"attributes": {
-					"timezone": "UTC",
-				}
-			}
+- #### Resources  
+To update a resources fields/metadata directly a PATCH request can be made to the resource's uri with the fields you wish to update.   
+https://jsonapi.org/format/#crud-updating  
+Example: updates the below observation object's timezone to UTC  
+
+```
+PATCH /observations/1234567891011121314 HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+	"data":{
+		"type": "observations",
+		"id": "1234567891011121314",
+		"attributes": {
+			"timezone": "UTC",
 		}
-	```
-Relationships:
-	https://jsonapi.org/format/#crud-updating-relationships
-	example: updates provider to different 
-	```
-		PATCH: /observations/<uuid>/provider
-		Content-Type: application/vnd.api+json
-		Accept: application/vnd.api+json
+	}
+}
+```
+- #### Relationships  
+To update relationship between resources a PATCH request can be made to the uri of the resource to which the relationship is assigned.  
+https://jsonapi.org/format/#crud-updating-relationships  
+Example: Updates provider relationship of a data (observation/forecast) resource.   
 
-		{
-			"data": { "type": "organizations", "id": "<uuid>" }
-		}
-	```
+```
+PATCH: /observations/1234567891011121314/provider
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+	"data": { "type": "organizations", "id": "<uuid>" }
+}
+```
 
 
-ORGANIZATIONS
+Organizations
+```
 {
 	"data":{
 		"type": "organizations",
@@ -93,8 +101,8 @@ ORGANIZATIONS
 		"relationships": {
 			"users": {
 				"data": [
-					{"type": "users", "id": "12"}, #probably a uuid instead of 2 digit number
-					{"type": "users", "id": "13"},
+					{"type": "users", "id": "<uuid>"},
+					{"type": "users", "id": "<uuid>"},
 				] 
 			},
 			"observations": {
@@ -125,3 +133,4 @@ ORGANIZATIONS
 		...
     ]
 }
+```

--- a/markdown_spec.md
+++ b/markdown_spec.md
@@ -1,9 +1,48 @@
 # JSON API response objects
-Solar Forecast arbiter API response objects based on the [JSON API](https://jsonapi.org/)
+**Objects and specification described in this document are provisional and subject to change**
+
+Solar Forecast arbiter API based on the [JSON API](https://jsonapi.org/) specification.
+
+This document is organized into sections based on resource type with sub sections describing specific *CRUD* (CREATE READ UPDATE DELETE) interactions.
 
 ## Observations/Forecasts
-Full Resource example.
+### Create
+- #### Resource
+Observation resources can be created by making a `POST` request with a payload containing a resource object without an `id` to the `/observation` endpoint.
+
 ```
+POST /observations HTTP/1.1
+Accept: application/vnd.api+json
+
+{
+	"data": {
+		"type": "observations",
+		"attributes": {
+			"name": "Ashland OR",
+            "resolution": "1 min",
+            "latitude": "42.190000",
+            "longitude": "-122.700000",
+            "elevation": "595",
+            "station_id": "94040",
+            "abbreviation": "AS",
+            "timezone": "Etc/GMT+8",
+            "attribution":  "NaN",
+            "source": "UO SRML",
+		}
+	}
+}
+```
+
+### Read
+- #### Resource
+To retrieve metadata about a data resource, a get request can be made to its uri.  
+https://jsonapi.org/format/#fetching-resources  
+Example: Get an observation resource.
+
+```
+GET /observations/1234567891011121314 HTTP/1.1
+Accept: application/vnd.api+json
+
 {
 	"data":{
 		"type": "observations",
@@ -15,7 +54,7 @@ Full Resource example.
 			"longitude": "-122.700000",
 			"elevation": "595",
 			"station_id": "94040",
-		    "abbreviation":	"AS",
+			"abbreviation":	"AS",
 			"timezone": "Etc/GMT+8",
 			"attribution":	"NaN",
 			"source": "UO SRML",
@@ -45,7 +84,7 @@ Full Resource example.
 	}]	
 }
 ```
-### Updating:
+### Update
 
 Updates are handled with the `PATCH` http verb.
 
@@ -85,8 +124,13 @@ Accept: application/vnd.api+json
 ```
 
 
-Organizations
+## Organizations
+
+### Read
+
 ```
+GET /organizations/1029 HTTP/1.1
+Accept: application/vnd.api+json
 {
 	"data":{
 		"type": "organizations",


### PR DESCRIPTION
@alorenzo175 @wholmgren I've created a provisional spec that conforms to JSON API. It's only fleshed out for Observations/Forecasts but I think it should be enough to weigh its merits and see if we want to go in that direction. I didn't include error responses or the 200-responses for create/update/delete for the time being.
I moved it to markdown because it seems easier to have people just look at a markdown file while we're developing instead of asking people to load the yaml spec into some renderer to view it. 